### PR TITLE
64bit Windows Server 2016 v2.5.1 running IIS 10.0 deprecated

### DIFF
--- a/templates/quickstart-dotnet-serverless-cicd.yml
+++ b/templates/quickstart-dotnet-serverless-cicd.yml
@@ -18,7 +18,7 @@ Parameters:
   SolutionStack:
     Type: String
     Description: The platform version for the .Net Elastic Beantalk environment, please check documentation for lastest platfrom version. 
-    Default: '64bit Windows Server 2016 v2.5.1 running IIS 10.0' 
+    Default: '64bit Windows Server 2016 v2.5.5 running IIS 10.0' 
   QSS3BucketName:
     AllowedPattern: ^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$
     ConstraintDescription: This string can include numbers, lowercase


### PR DESCRIPTION
64bit Windows Server 2016 v2.5.5 running IIS 10.0 current version

*Issue # 17*

64bit Windows Server 2016 v2.5.5 running IIS 10.0 current solution stack for EB

